### PR TITLE
Qt5/Qt6 interoperability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,10 @@ project(KDSingleApplication
 cmake_policy(SET CMP0020 NEW)
 cmake_policy(SET CMP0042 NEW)
 
-find_package(Qt5Widgets)
-find_package(Qt5Network)
+find_package(Qt6 COMPONENTS Network)
+if (NOT Qt6_FOUND)
+    find_package(Qt5 5.15 COMPONENTS Network REQUIRED)
+endif (NOT Qt6_FOUND)
 
 set(CMAKE_AUTOMOC ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,8 @@ project(KDSingleApplication
 cmake_policy(SET CMP0020 NEW)
 cmake_policy(SET CMP0042 NEW)
 
-find_package(Qt6 COMPONENTS Network)
-if (NOT Qt6_FOUND)
-    find_package(Qt5 5.15 COMPONENTS Network REQUIRED)
-endif (NOT Qt6_FOUND)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Network REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Network REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(kdsingleapplication
 if (WIN32)
     target_link_libraries(kdsingleapplication kernel32)
 endif()
-target_link_libraries(kdsingleapplication Qt::Core Qt::Network)
+target_link_libraries(kdsingleapplication Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network)
 
 install (FILES ${KDSINGLEAPPLICATION_INSTALLABLE_INCLUDES} DESTINATION ${KDSINGLEAPPLICATION_INCLUDEDIR})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(kdsingleapplication
 if (WIN32)
     target_link_libraries(kdsingleapplication kernel32)
 endif()
-target_link_libraries(kdsingleapplication Qt5::Core Qt5::Network)
+target_link_libraries(kdsingleapplication Qt::Core Qt::Network)
 
 install (FILES ${KDSINGLEAPPLICATION_INSTALLABLE_INCLUDES} DESTINATION ${KDSINGLEAPPLICATION_INCLUDEDIR})
 


### PR DESCRIPTION
This pull requests implements two things

-  Removes an unused reference to the Widgets module of Qt
-  Make the code compile with both Qt5 and Qt6. The implementation follows the pattern suggested by @dantti in response of my previous pull request.

I would be glad if you could consider this request. Thank you for your great contributions! I appreciate it greatly.

Best

Stefan.