### PR TITLE
Fix compile warnings with -Wshadow

### DIFF
--- a/src/kdsingleapplication_localsocket.cpp
+++ b/src/kdsingleapplication_localsocket.cpp
@@ -298,8 +298,8 @@ void KDSingleApplicationLocalSocket::abortConnectionToSecondary()
     qCDebug(kdsaLocalSocket) << "Secondary timed out. Data read:" << c.readData;
 }
 
-KDSingleApplicationLocalSocket::Connection::Connection(QLocalSocket *socket)
-    : socket(socket)
+KDSingleApplicationLocalSocket::Connection::Connection(QLocalSocket *_socket)
+    : socket(_socket)
     , timeoutTimer(new QTimer)
 {
     timeoutTimer->start(LOCALSOCKET_CONNECTION_TIMEOUT);

--- a/src/kdsingleapplication_localsocket_p.h
+++ b/src/kdsingleapplication_localsocket_p.h
@@ -43,8 +43,8 @@ public:
     {
     }
 
-    explicit QObjectConnectionHolder(QMetaObject::Connection c)
-        : c(std::move(c))
+    explicit QObjectConnectionHolder(QMetaObject::Connection _c)
+        : c(std::move(_c))
     {
     }
 


### PR DESCRIPTION
Example: error: declaration of ‘c’ shadows a member of ‘QObjectConnectionHolder’ [-Werror=shadow]