### PR TITLE
KDSingleApplicationLocalSocket: Remove std::move in handleNewConnection

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,9 @@ endif()
 add_library(
     KDAB::kdsingleapplication ALIAS kdsingleapplication
 )
-set_target_properties(kdsingleapplication PROPERTIES OUTPUT_NAME "kdsingleapplication${KDSingleApplication_LIBRARY_QTID}")
+set_target_properties(
+    kdsingleapplication PROPERTIES OUTPUT_NAME "kdsingleapplication${KDSingleApplication_LIBRARY_QTID}"
+)
 
 target_include_directories(
     kdsingleapplication
@@ -57,10 +59,13 @@ if(${PROJECT_NAME}_IS_ROOT_PROJECT)
         NAMESPACE KDAB::
         DESTINATION ${INSTALL_LIBRARY_DIR}/cmake/KDSingleApplication${KDSingleApplication_LIBRARY_QTID}
     )
-    configure_file(KDSingleApplicationConfig.cmake.in KDSingleApplication${KDSingleApplication_LIBRARY_QTID}Config.cmake @ONLY)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/KDSingleApplication${KDSingleApplication_LIBRARY_QTID}Config.cmake"
-                  "${CMAKE_CURRENT_BINARY_DIR}/KDSingleApplication${KDSingleApplication_LIBRARY_QTID}ConfigVersion.cmake"
-            DESTINATION "${INSTALL_LIBRARY_DIR}/cmake/KDSingleApplication${KDSingleApplication_LIBRARY_QTID}"
+    configure_file(
+        KDSingleApplicationConfig.cmake.in KDSingleApplication${KDSingleApplication_LIBRARY_QTID}Config.cmake @ONLY
+    )
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/KDSingleApplication${KDSingleApplication_LIBRARY_QTID}Config.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/KDSingleApplication${KDSingleApplication_LIBRARY_QTID}ConfigVersion.cmake"
+        DESTINATION "${INSTALL_LIBRARY_DIR}/cmake/KDSingleApplication${KDSingleApplication_LIBRARY_QTID}"
     )
 
     include(ECMGenerateHeaders)

--- a/src/kdsingleapplication_localsocket.cpp
+++ b/src/kdsingleapplication_localsocket.cpp
@@ -184,7 +184,7 @@ void KDSingleApplicationLocalSocket::handleNewConnection()
     while ((socket = m_localServer->nextPendingConnection())) {
         qCDebug(kdsaLocalSocket) << "Got new connection on" << m_socketName << "state" << socket->state();
 
-        Connection c(std::move(socket));
+        Connection c(socket);
         socket = c.socket.get();
 
         c.readDataConnection = QObjectConnectionHolder(


### PR DESCRIPTION
`socket` is a pointer so `std::move` is pointless here.