### PR TITLE
Add options and new constructor with options

### DIFF
--- a/src/kdsingleapplication.cpp
+++ b/src/kdsingleapplication.cpp
@@ -21,7 +21,7 @@
 class KDSingleApplicationPrivate
 {
 public:
-    explicit KDSingleApplicationPrivate(const QString &name, KDSingleApplication *q);
+    explicit KDSingleApplicationPrivate(const QString &name, KDSingleApplication::Options options, KDSingleApplication *q);
 
     QString name() const
     {
@@ -47,10 +47,10 @@ private:
     KDSingleApplicationLocalSocket m_impl;
 };
 
-KDSingleApplicationPrivate::KDSingleApplicationPrivate(const QString &name, KDSingleApplication *q)
+KDSingleApplicationPrivate::KDSingleApplicationPrivate(const QString &name, KDSingleApplication::Options options, KDSingleApplication *q)
     : q_ptr(q)
     , m_name(name)
-    , m_impl(name)
+    , m_impl(name, options)
 {
     if (Q_UNLIKELY(name.isEmpty()))
         qFatal("KDSingleApplication requires a non-empty application name");
@@ -73,7 +73,13 @@ KDSingleApplication::KDSingleApplication(QObject *parent)
 
 KDSingleApplication::KDSingleApplication(const QString &name, QObject *parent)
     : QObject(parent)
-    , d_ptr(new KDSingleApplicationPrivate(name, this))
+    , d_ptr(new KDSingleApplicationPrivate(name, Option::IncludeUsernameInSocketName | Option::IncludeSessionInSocketName, this))
+{
+}
+
+KDSingleApplication::KDSingleApplication(const QString &name, const Options options, QObject *parent)
+    : QObject(parent)
+    , d_ptr(new KDSingleApplicationPrivate(name, options, this))
 {
 }
 

--- a/src/kdsingleapplication.h
+++ b/src/kdsingleapplication.h
@@ -11,6 +11,7 @@
 #define KDSINGLEAPPLICATION_H
 
 #include <QtCore/QObject>
+#include <QtCore/QFlags>
 
 #include <memory>
 
@@ -25,8 +26,18 @@ class KDSINGLEAPPLICATION_EXPORT KDSingleApplication : public QObject
     Q_PROPERTY(bool isPrimaryInstance READ isPrimaryInstance CONSTANT)
 
 public:
+    // IncludeUsernameInSocketName - Include the username in the socket name.
+    // IncludeSessionInSocketName - Include the graphical session in the socket name.
+    enum class Option {
+        None = 0x0,
+        IncludeUsernameInSocketName = 0x1,
+        IncludeSessionInSocketName = 0x2,
+    };
+    Q_DECLARE_FLAGS(Options, Option)
+
     explicit KDSingleApplication(QObject *parent = nullptr);
     explicit KDSingleApplication(const QString &name, QObject *parent = nullptr);
+    explicit KDSingleApplication(const QString &name, Options options, QObject *parent = nullptr);
     ~KDSingleApplication();
 
     QString name() const;
@@ -44,5 +55,7 @@ private:
     Q_DECLARE_PRIVATE(KDSingleApplication)
     std::unique_ptr<KDSingleApplicationPrivate> d_ptr;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(KDSingleApplication::Options)
 
 #endif // KDSINGLEAPPLICATION_H

--- a/src/kdsingleapplication_localsocket_p.h
+++ b/src/kdsingleapplication_localsocket_p.h
@@ -25,6 +25,8 @@ QT_END_NAMESPACE
 #include <memory>
 #include <vector>
 
+#include "kdsingleapplication.h"
+
 struct QObjectDeleteLater
 {
     void operator()(QObject *o)
@@ -78,6 +80,7 @@ class KDSingleApplicationLocalSocket : public QObject
 
 public:
     explicit KDSingleApplicationLocalSocket(const QString &name,
+                                            KDSingleApplication::Options options,
                                             QObject *parent = nullptr);
     ~KDSingleApplicationLocalSocket();
 


### PR DESCRIPTION
Adding options making session ID part of the socket name optional, more options can be added in the future. To maintain source and binary compatibility I've added a new constructor taking options. The old constructors will default to using the session option, taking session ID as part of the socket name by default.

Fixes #13