### PR TITLE
KDSingleApplication: Remove const

### DIFF
--- a/src/kdsingleapplication.cpp
+++ b/src/kdsingleapplication.cpp
@@ -77,7 +77,7 @@ KDSingleApplication::KDSingleApplication(const QString &name, QObject *parent)
 {
 }
 
-KDSingleApplication::KDSingleApplication(const QString &name, const Options options, QObject *parent)
+KDSingleApplication::KDSingleApplication(const QString &name, Options options, QObject *parent)
     : QObject(parent)
     , d_ptr(new KDSingleApplicationPrivate(name, options, this))
 {


### PR DESCRIPTION
There isn't const on the declaration or the options parameter elsewhere.