### PR TITLE
src/CMakeLists.txt - set VERSION and SOVERSION on the library target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,10 @@ add_library(
     KDAB::kdsingleapplication ALIAS kdsingleapplication
 )
 set_target_properties(
-    kdsingleapplication PROPERTIES OUTPUT_NAME "kdsingleapplication${KDSingleApplication_LIBRARY_QTID}"
+    kdsingleapplication
+    PROPERTIES VERSION ${${PROJECT_NAME}_VERSION}
+               SOVERSION ${${PROJECT_NAME}_SOVERSION}
+               OUTPUT_NAME "kdsingleapplication${${PROJECT_NAME}_LIBRARY_QTID}"
 )
 
 target_include_directories(


### PR DESCRIPTION
The version variables are currently only passed to ecm_setup_version(), but they need to be also specified as target properties so that CMake installs versioned .so files on Linux, which is required for proper distribution packaging.