### PR TITLE
Standardize project to KDAB copyright policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: MIT
 #
 # Contact KDAB at <info@kdab.com> for commercial licensing options.
+#
 
 # dot should come with Doxygen find_package(Doxygen)
 if(DOXYGEN_DOT_EXECUTABLE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/widgetsingleapplication/CMakeLists.txt
+++ b/examples/widgetsingleapplication/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/examples/widgetsingleapplication/main.cpp
+++ b/examples/widgetsingleapplication/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/examples/widgetsingleapplication/primaryinstancewidget.cpp
+++ b/examples/widgetsingleapplication/primaryinstancewidget.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/examples/widgetsingleapplication/primaryinstancewidget.h
+++ b/examples/widgetsingleapplication/primaryinstancewidget.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/examples/widgetsingleapplication/secondaryinstancewidget.cpp
+++ b/examples/widgetsingleapplication/secondaryinstancewidget.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/examples/widgetsingleapplication/secondaryinstancewidget.h
+++ b/examples/widgetsingleapplication/secondaryinstancewidget.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/KDSingleApplicationConfig.cmake.in
+++ b/src/KDSingleApplicationConfig.cmake.in
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/src/kdsingleapplication.cpp
+++ b/src/kdsingleapplication.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/src/kdsingleapplication.h
+++ b/src/kdsingleapplication.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/src/kdsingleapplication_lib.h
+++ b/src/kdsingleapplication_lib.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/src/kdsingleapplication_localsocket.cpp
+++ b/src/kdsingleapplication_localsocket.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/src/kdsingleapplication_localsocket_p.h
+++ b/src/kdsingleapplication_localsocket_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/auto/simpletest/CMakeLists.txt
+++ b/tests/auto/simpletest/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/auto/simpletest/simpletest/CMakeLists.txt
+++ b/tests/auto/simpletest/simpletest/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/auto/simpletest/simpletest/main.cpp
+++ b/tests/auto/simpletest/simpletest/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/tests/auto/simpletest/test/CMakeLists.txt
+++ b/tests/auto/simpletest/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/auto/simpletest/tst_simpletest.cpp
+++ b/tests/auto/simpletest/tst_simpletest.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/tests/auto/stresstest/CMakeLists.txt
+++ b/tests/auto/stresstest/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/auto/stresstest/stresstest/CMakeLists.txt
+++ b/tests/auto/stresstest/stresstest/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/auto/stresstest/stresstest/main.cpp
+++ b/tests/auto/stresstest/stresstest/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/tests/auto/stresstest/stresstest2/CMakeLists.txt
+++ b/tests/auto/stresstest/stresstest2/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/auto/stresstest/stresstest2/main.cpp
+++ b/tests/auto/stresstest/stresstest2/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/tests/auto/stresstest/test/CMakeLists.txt
+++ b/tests/auto/stresstest/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/auto/stresstest/tst_stresstest.cpp
+++ b/tests/auto/stresstest/tst_stresstest.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 

--- a/tests/manual/CMakeLists.txt
+++ b/tests/manual/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/manual/simplesingleapp/CMakeLists.txt
+++ b/tests/manual/simplesingleapp/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file is part of KDSingleApplication.
 #
-# SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/tests/manual/simplesingleapp/main.cpp
+++ b/tests/manual/simplesingleapp/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDSingleApplication.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
For individual files: use year of file creation
For entire project:
  remove year from the statement
  use the © where feasible

reference:
https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code