### PR TITLE
KDSingleApplication: Do not exceed maximum socket name length

### DIFF
--- a/src/kdsingleapplication_localsocket.cpp
+++ b/src/kdsingleapplication_localsocket.cpp
@@ -85,6 +85,10 @@ KDSingleApplicationLocalSocket::KDSingleApplicationLocalSocket(const QString &na
         userName = alternativeUserName;
     }
 #elif defined(Q_OS_WIN)
+
+    constexpr int maxSocketNameLength = MAX_PATH - 1;
+    const int tempPathLength = 16; // "\\.\pipe\LOCAL\"
+
     // I'm not sure of a "global session identifier" on Windows; are
     // multiple logins from the same user a possibility? For now, following this:
     // https://docs.microsoft.com/en-us/windows/desktop/devnotes/getting-the-session-id-of-the-current-process
@@ -119,7 +123,6 @@ KDSingleApplicationLocalSocket::KDSingleApplicationLocalSocket(const QString &na
     m_socketName += QStringLiteral("-");
     m_socketName += name;
 
-#if defined(Q_OS_UNIX)
     int fullSocketNameLength = tempPathLength + m_socketName.length();
 #if defined(Q_OS_LINUX) || defined(Q_OS_QNX)
     fullSocketNameLength += 1; // PlatformSupportsAbstractNamespace, see qlocalserver_unix.cpp
@@ -128,7 +131,6 @@ KDSingleApplicationLocalSocket::KDSingleApplicationLocalSocket(const QString &na
         qCDebug(kdsaLocalSocket) << "Chopping socket name because it is longer than" << maxSocketNameLength;
         m_socketName.chop(fullSocketNameLength - maxSocketNameLength);
     }
-#endif
 
     const QString lockFilePath =
         QDir::tempPath() + QLatin1Char('/') + m_socketName + QLatin1String(".lock");

--- a/src/kdsingleapplication_localsocket.cpp
+++ b/src/kdsingleapplication_localsocket.cpp
@@ -122,7 +122,7 @@ KDSingleApplicationLocalSocket::KDSingleApplicationLocalSocket(const QString &na
 #if defined(Q_OS_UNIX)
     int fullSocketNameLength = tempPathLength + m_socketName.length();
 #if defined(Q_OS_LINUX) || defined(Q_OS_QNX)
-    fullSocketNameLength += 1;  // PlatformSupportsAbstractNamespace, see qlocalserver_unix.cpp
+    fullSocketNameLength += 1; // PlatformSupportsAbstractNamespace, see qlocalserver_unix.cpp
 #endif
     if (fullSocketNameLength > maxSocketNameLength) {
         qCDebug(kdsaLocalSocket) << "Chopping socket name because it is longer than" << maxSocketNameLength;

--- a/tests/auto/namelengthtest/CMakeLists.txt
+++ b/tests/auto/namelengthtest/CMakeLists.txt
@@ -6,6 +6,5 @@
 #
 # Contact KDAB at <info@kdab.com> for commercial licensing options.
 #
-add_subdirectory(simpletest)
-add_subdirectory(stresstest)
 add_subdirectory(namelengthtest)
+add_subdirectory(test)

--- a/tests/auto/namelengthtest/namelengthtest/CMakeLists.txt
+++ b/tests/auto/namelengthtest/namelengthtest/CMakeLists.txt
@@ -6,6 +6,11 @@
 #
 # Contact KDAB at <info@kdab.com> for commercial licensing options.
 #
-add_subdirectory(simpletest)
-add_subdirectory(stresstest)
-add_subdirectory(namelengthtest)
+set(namelengthtest_SRCS main.cpp)
+add_executable(
+    namelengthtest
+    ${namelengthtest_SRCS}
+)
+target_link_libraries(
+    namelengthtest Qt::Widgets kdsingleapplication
+)

--- a/tests/auto/namelengthtest/namelengthtest/main.cpp
+++ b/tests/auto/namelengthtest/namelengthtest/main.cpp
@@ -1,0 +1,59 @@
+/*
+  This file is part of KDSingleApplication.
+
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: MIT
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QStringList>
+#include <QtCore/QString>
+#include <QtCore/QTimer>
+
+#include <kdsingleapplication.h>
+
+#include <iostream>
+
+#if defined(Q_OS_WIN)
+#include <io.h>
+#include <fcntl.h>
+#endif
+
+int main(int argc, char **argv)
+{
+#if defined(Q_OS_WIN)
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
+
+    QCoreApplication app(argc, argv);
+
+    const QString appName = QLatin1String("namelengthtest-") + app.arguments().value(1);
+
+    KDSingleApplication kdsa(QStringLiteral("a").repeated(9000));
+
+    if (kdsa.isPrimaryInstance()) {
+        std::cout << "Primary" << std::endl;
+
+        QObject::connect(&kdsa, &KDSingleApplication::messageReceived, qApp,
+                         [](const QByteArray &message) {
+                             std::cout << "MESSAGE: >" << message.constData() << '<' << std::endl;
+                             qApp->quit();
+                         });
+
+        QTimer::singleShot(5000, qApp, []() { qApp->exit(1); });
+
+        return app.exec();
+    } else {
+        std::cout << "Secondary" << std::endl;
+
+        if (!kdsa.sendMessage(app.arguments().value(2).toUtf8())) {
+            std::cerr << "Unable to send message to the primary!" << std::endl;
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/tests/auto/namelengthtest/test/CMakeLists.txt
+++ b/tests/auto/namelengthtest/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+# This file is part of KDSingleApplication.
+#
+# SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+#
+# SPDX-License-Identifier: MIT
+#
+# Contact KDAB at <info@kdab.com> for commercial licensing options.
+#
+include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_executable(
+    tst_namelengthtest
+    ../tst_namelengthtest.cpp
+)
+target_link_libraries(
+    tst_namelengthtest Qt::Test
+)
+add_test(NAME tst_namelengthtest COMMAND tst_namelengthtest)

--- a/tests/auto/namelengthtest/tst_namelengthtest.cpp
+++ b/tests/auto/namelengthtest/tst_namelengthtest.cpp
@@ -1,0 +1,102 @@
+/*
+  This file is part of KDSingleApplication.
+
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: MIT
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#include <QtCore/QProcess>
+#include <QtCore/QRandomGenerator>
+#include <QtTest/QTest>
+
+
+#include <vector>
+#include <memory>
+
+// runs a primary, runs a secondary, checks that a message is received.
+
+class tst_NameLengthTest : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+    void testNameLength_data();
+    void testNameLength();
+};
+
+void tst_NameLengthTest::testNameLength_data()
+{
+    QTest::addColumn<QString>("message");
+
+    QTest::addRow("message-1") << QStringLiteral("Hello");
+    QTest::addRow("message-2") << QStringLiteral("Hello World");
+    QTest::addRow("message-3") << QStringLiteral("Hello World 123456789");
+    // QTest::addRow("message empty") << QString();
+
+    for (int i = 1; i <= 2048; i *= 2) {
+        QTest::addRow("message-x-%d", i) << QString(i, QLatin1Char('x'));
+    }
+}
+
+void tst_NameLengthTest::testNameLength()
+{
+    QFETCH(QString, message);
+#ifdef KDSINGLEAPPLICATION_BINARY_DIR
+    const QString executable = QStringLiteral(KDSINGLEAPPLICATION_BINARY_DIR "namelengthtest");
+#else
+    const QString executable = QStringLiteral("namelengthtest/namelengthtest");
+#endif
+    QByteArray output;
+    bool ok;
+
+    const QString testId = QString::number(QRandomGenerator::global()->generate());
+
+    QProcess primary;
+    primary.setProcessChannelMode(QProcess::ForwardedErrorChannel);
+    primary.start(executable, { testId });
+    QVERIFY(primary.waitForStarted());
+    QCOMPARE(primary.state(), QProcess::Running);
+    output.clear();
+    ok = QTest::qWaitFor([&]() {
+        output += primary.readAllStandardOutput();
+        return output == "Primary\n";
+    });
+    QVERIFY(ok);
+
+    QProcess secondary;
+    secondary.setProcessChannelMode(QProcess::ForwardedErrorChannel);
+    secondary.start(executable, { testId, message });
+    QVERIFY(secondary.waitForStarted());
+    QCOMPARE(secondary.state(), QProcess::Running);
+
+    output.clear();
+    ok = QTest::qWaitFor([&]() {
+        output += secondary.readAllStandardOutput();
+        return output == "Secondary\n";
+    });
+    QVERIFY(ok);
+
+    if (secondary.state() != QProcess::NotRunning)
+        QVERIFY(secondary.waitForFinished());
+    QCOMPARE(secondary.exitCode(), 0);
+    QCOMPARE(secondary.exitStatus(), QProcess::NormalExit);
+
+    output.clear();
+    const QByteArray expected = "MESSAGE: >" + message.toUtf8() + "<\n";
+    ok = QTest::qWaitFor([&]() {
+        output += primary.readAllStandardOutput();
+        return output == expected;
+    });
+    QVERIFY(ok);
+
+    if (primary.state() != QProcess::NotRunning)
+        QVERIFY(primary.waitForFinished());
+    QCOMPARE(primary.exitCode(), 0);
+    QCOMPARE(primary.exitStatus(), QProcess::NormalExit);
+}
+
+QTEST_MAIN(tst_NameLengthTest)
+
+#include "tst_namelengthtest.moc"


### PR DESCRIPTION
In cases where there is a long name given (usually the application name) or a long username, `QLocalServer::listen` fails because `sockaddr_un.sun_path` has a char array of 108 on Linux, and 104 on BSD/macOS. On macOS, the TMPDIR path is long, ie.: `/var/folders/zg/b242mhvd125344h5zrnpkzk80000gn/T/`, so 49 characters just for the temp path alone. To fix this, use the uid instead of the username if the total length of the socket name is expected to exceed the maximum length. If it still exceeds the maximum allowed length, ie.: the given name is too long, chop the socket name which cuts off the last part of the name.

I've tested this to work on both Linux and macOS, Windows should be unaffected by these changes.

Fixes https://github.com/strawberrymusicplayer/strawberry/issues/1603