### PR TITLE
Socketname length changes followup

### DIFF
--- a/src/kdsingleapplication_localsocket.cpp
+++ b/src/kdsingleapplication_localsocket.cpp
@@ -74,16 +74,13 @@ KDSingleApplicationLocalSocket::KDSingleApplicationLocalSocket(const QString &na
         struct passwd *pw = ::getpwuid(uid);
         userName = pw ? QString::fromUtf8(pw->pw_name) : alternativeUserName;
     }
-    if (options.testFlag(KDSingleApplication::Option::IncludeSessionInSocketName)) {
+    if (options.testFlag(KDSingleApplication::Option::IncludeSessionInSocketName))
         sessionId = qEnvironmentVariable("XDG_SESSION_ID");
-    }
     int socketNameLength = tempPathLength + m_socketName.length() + 1 + name.length() + 1 + userName.length();
-    if (options.testFlag(KDSingleApplication::Option::IncludeSessionInSocketName) && !sessionId.isEmpty()) {
+    if (options.testFlag(KDSingleApplication::Option::IncludeSessionInSocketName) && !sessionId.isEmpty())
         socketNameLength += sessionId.length() + 1;
-    }
-    if (socketNameLength > maxSocketNameLength) {
+    if (socketNameLength > maxSocketNameLength)
         userName = alternativeUserName;
-    }
 #elif defined(Q_OS_WIN)
 
     constexpr int maxSocketNameLength = MAX_PATH - 1;
@@ -95,16 +92,14 @@ KDSingleApplicationLocalSocket::KDSingleApplicationLocalSocket(const QString &na
     if (options.testFlag(KDSingleApplication::Option::IncludeUsernameInSocketName)) {
         DWORD usernameLen = UNLEN + 1;
         wchar_t username[UNLEN + 1];
-        if (GetUserNameW(username, &usernameLen)) {
+        if (GetUserNameW(username, &usernameLen))
             userName = QString::fromWCharArray(username);
-        }
     }
     if (options.testFlag(KDSingleApplication::Option::IncludeSessionInSocketName)) {
         DWORD pSessionId;
         BOOL haveSessionId = ProcessIdToSessionId(GetCurrentProcessId(), &pSessionId);
-        if (haveSessionId) {
+        if (haveSessionId)
             sessionId = QString::number(pSessionId);
-        }
     }
 #else
 #error "KDSingleApplication has not been ported to this platform"

--- a/src/kdsingleapplication_localsocket.cpp
+++ b/src/kdsingleapplication_localsocket.cpp
@@ -30,9 +30,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <pwd.h>
-#if defined(Q_OS_LINUX)
-#include <linux/un.h>
-#endif
+#include <sys/un.h>
 #endif
 
 #if defined(Q_OS_WIN)
@@ -59,11 +57,7 @@ KDSingleApplicationLocalSocket::KDSingleApplicationLocalSocket(const QString &na
 #if defined(Q_OS_UNIX)
 
     // Make sure the socket name does not exceed the size of sockaddr_un.sun_path
-#ifdef Q_OS_LINUX
-    constexpr int maxSocketNameLength = UNIX_PATH_MAX - 1;
-#else
-    constexpr int maxSocketNameLength = 103; // BSD and macOS
-#endif
+    constexpr int maxSocketNameLength = sizeof(sockaddr_un::sun_path) - 1;
 
     const int tempPathLength = QDir::cleanPath(QDir::tempPath()).length() + 1;
 


### PR DESCRIPTION
Fixes incorrect formatting and use `sizeof(sockaddr_un::sun_path)` instead `UNIX_PATH_MAX`