### PR TITLE
KDSingleApplication now looks for Qt6 by default, rather than Qt5.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # -DKDSingleApplication_QT6=[true|false]
 #  Build against Qt6 rather than Qt5
-#  Default=false (Qt5 will be used even if Qt6 is available)
+#  Default=true
 #
 # -DKDSingleApplication_STATIC=[true|false]
 #  Build static versions of the libraries
@@ -63,7 +63,7 @@ cmake_policy(SET CMP0042 NEW)
 
 include(FeatureSummary)
 
-option(${PROJECT_NAME}_QT6 "Build against Qt 6" OFF)
+option(${PROJECT_NAME}_QT6 "Build against Qt 6" ON)
 option(${PROJECT_NAME}_DEVELOPER_MODE "Developer Mode" OFF)
 option(${PROJECT_NAME}_TESTS "Build the tests" OFF)
 option(${PROJECT_NAME}_EXAMPLES "Build the examples" ON)

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 * v1.2.0 (unreleased)
- -
+ - KDSingleApplication now looks for Qt6 by default, rather than Qt5. If your Qt5
+   build broke, pass -DKDSingleApplication_QT6=OFF to CMake.
 
 * v1.1.1 (unreleased)
  -

--- a/distro/qt5-debian.rules
+++ b/distro/qt5-debian.rules
@@ -1,4 +1,4 @@
 #!/usr/bin/make -f
-DEB_CMAKE_EXTRA_FLAGS = -DCMAKE_BUILD_TYPE=Release -DKDSingleApplication_STATIC=True
+DEB_CMAKE_EXTRA_FLAGS = -DCMAKE_BUILD_TYPE=Release -DKDSingleApplication_QT6=False -DKDSingleApplication_STATIC=True
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/cmake.mk

--- a/distro/qt5-kdsingleapplication.spec
+++ b/distro/qt5-kdsingleapplication.spec
@@ -61,7 +61,7 @@ develop programs using kdsingleapplication.
 %autosetup
 
 %build
-cmake . -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDSingleApplication_STATIC=True
+cmake . -DCMAKE_INSTALL_PREFIX=/usr -DKDSingleApplication_QT6=False -DCMAKE_BUILD_TYPE=Release -DKDSingleApplication_STATIC=True
 %__make %{?_smp_mflags}
 
 %post -p /sbin/ldconfig


### PR DESCRIPTION
If your Qt5 build broke, pass -DKDSingleApplication_QT6=OFF to CMake.