### PR TITLE
ci: make dependabot less noisy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: monthly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
- It's now weekly instead of daily.
- Group all PRs into one.