### PR TITLE
Fix d_ptr shadowing QObject::d_ptr causing -Wshadow-all failure

### DIFF
--- a/src/kdsingleapplication.cpp
+++ b/src/kdsingleapplication.cpp
@@ -73,13 +73,13 @@ KDSingleApplication::KDSingleApplication(QObject *parent)
 
 KDSingleApplication::KDSingleApplication(const QString &name, QObject *parent)
     : QObject(parent)
-    , d_ptr(new KDSingleApplicationPrivate(name, Option::IncludeUsernameInSocketName | Option::IncludeSessionInSocketName, this))
+    , m_dPtr(new KDSingleApplicationPrivate(name, Option::IncludeUsernameInSocketName | Option::IncludeSessionInSocketName, this))
 {
 }
 
 KDSingleApplication::KDSingleApplication(const QString &name, Options options, QObject *parent)
     : QObject(parent)
-    , d_ptr(new KDSingleApplicationPrivate(name, options, this))
+    , m_dPtr(new KDSingleApplicationPrivate(name, options, this))
 {
 }
 

--- a/src/kdsingleapplication.h
+++ b/src/kdsingleapplication.h
@@ -52,8 +52,14 @@ Q_SIGNALS:
     void messageReceived(const QByteArray &message);
 
 private:
-    KDSingleApplicationPrivate *d_func() { return m_dPtr.get(); }
-    const KDSingleApplicationPrivate *d_func() const { return m_dPtr.get(); }
+    KDSingleApplicationPrivate *d_func()
+    {
+        return m_dPtr.get();
+    }
+    const KDSingleApplicationPrivate *d_func() const
+    {
+        return m_dPtr.get();
+    }
     friend class KDSingleApplicationPrivate;
     std::unique_ptr<KDSingleApplicationPrivate> m_dPtr;
 };

--- a/src/kdsingleapplication.h
+++ b/src/kdsingleapplication.h
@@ -52,8 +52,10 @@ Q_SIGNALS:
     void messageReceived(const QByteArray &message);
 
 private:
-    Q_DECLARE_PRIVATE(KDSingleApplication)
-    std::unique_ptr<KDSingleApplicationPrivate> d_ptr;
+    KDSingleApplicationPrivate *d_func() { return m_dPtr.get(); }
+    const KDSingleApplicationPrivate *d_func() const { return m_dPtr.get(); }
+    friend class KDSingleApplicationPrivate;
+    std::unique_ptr<KDSingleApplicationPrivate> m_dPtr;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(KDSingleApplication::Options)


### PR DESCRIPTION
## Summary
- Renamed the `d_ptr` member variable to `m_dPtr` to avoid shadowing `QObject::d_ptr`
- Replaced `Q_DECLARE_PRIVATE` macro with hand-written `d_func()` methods

## Changes
| File | Change |
|------|--------|
| `src/kdsingleapplication.h` | Renamed `d_ptr` to `m_dPtr`, replaced `Q_DECLARE_PRIVATE` with manual `d_func()` methods |
| `src/kdsingleapplication.cpp` | Updated member initialization in constructors |

## Context

The `Q_DECLARE_PRIVATE` macro generates a `d_func()` method that internally references `d_ptr`. Simply renaming the member would break this generated code, so the macro was replaced with explicit hand-written `d_func()` overloads that return `m_dPtr.get()`.

The new name `m_dPtr` follows the existing member naming convention in the codebase (`m_socketName`, `m_lockFile`, `m_localServer`, etc.).

## Test Plan
- [x] Build passes with default flags
- [x] Build passes with `-Werror -Wshadow`
- [x] All 4 existing tests pass (`tst_simpletest`, `tst_stresstest`, `tst_namelengthtest`, `tst_disconnectduringreadtest`)

Fixes #121